### PR TITLE
handle reading error from input stream

### DIFF
--- a/Connection.m
+++ b/Connection.m
@@ -285,10 +285,10 @@ static char pendingIncomingMessageIdentifierKey;
 		int headerLen = [_inputStream read:header maxLength:readLen];
 		_receivedHeaderLength += headerLen;
 
-    //check for error in reading from input stream
-    if (headerLen <= 0)
+		//check for error in reading from input stream
+		if (headerLen <= 0)
 		{
-      //error occurred in reading data
+			//error occurred in reading data
 			[self closeConnection];
 			return;
 		}

--- a/Connection.m
+++ b/Connection.m
@@ -284,7 +284,15 @@ static char pendingIncomingMessageIdentifierKey;
 		uint8_t header[readLen];
 		int headerLen = [_inputStream read:header maxLength:readLen];
 		_receivedHeaderLength += headerLen;
-		
+
+    //check for error in reading from input stream
+    if (headerLen <= 0)
+		{
+      //error occurred in reading data
+			[self closeConnection];
+			return;
+		}
+
 		if (_receivedHeaderData == nil) _receivedHeaderData = [NSMutableData new];
 		[_receivedHeaderData appendBytes:(const void *)header length:headerLen];
 		


### PR DESCRIPTION
My tweak encounters a zero headerLen frequently and a negative-one headerLen occasionally. 
This patch prevents libobjcipc from crashing the hooked app (including SpringBoard).
